### PR TITLE
Automated Remediation Patch

### DIFF
--- a/ecr.tf
+++ b/ecr.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "ap-southeast-1"
+}
+resource "aws_ecr_repository" "scrooge_ecr" {
+  name                 = "scrooge-ecr"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  image_tag_mutability = "IMMUTABLE"
+}


### PR DESCRIPTION
This PR contains automated security/configuration remediations.

## Remediation Report
```json
{
  "original_filename": "ecr.tf",
  "patched_content": "provider \"aws\" {\n  region = \"ap-southeast-1\"\n}\nresource \"aws_ecr_repository\" \"scrooge_ecr\" {\n  name                 = \"scrooge-ecr\"\n\n  image_scanning_configuration {\n    scan_on_push = true\n  }\n\n  image_tag_mutability = \"IMMUTABLE\"\n}",
  "policy_compliance": {
    "violations_detected": 1,
    "validation_status": "FAILED",
    "policy_file_used": "policy/deny.rego"
  },
  "changes_summary": {
    "total_changes": 1,
    "changes_detail": [
      {
        "type": "ADDED",
        "content": "image_tag_mutability = \"IMMUTABLE\"",
        "description": "Added: image_tag_mutability = \"IMMUTABLE\""
      }
    ]
  },
  "violations_analysis": {
    "raw_violations": "\u001b[31mFAIL\u001b[0m - sample-configs/ecr.tf - main - ECR repository `scrooge_ecr` does not have image tag mutability set\n\n\u001b[31m4 tests, 3 passed, 0 warnings, 1 failure, 0 exceptions\u001b[0m\n"
  },
  "validation_details": {
    "original_file_validation": "\u001b[31mFAIL\u001b[0m - sample-configs/ecr.tf - main - ECR repository `scrooge_ecr` does not have image tag mutability set\n\n\u001b[31m4 tests, 3 passed, 0 warnings, 1 failure, 0 exceptions\u001b[0m\n",
    "patched_file_validation": "\n\u001b[32m4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions\u001b[0m\n",
    "original_tests_summary": {
      "total_tests": 4,
      "passed": 3,
      "warnings": 0,
      "failures": 1,
      "exceptions": 0
    },
    "patched_tests_summary": {
      "total_tests": 4,
      "passed": 4,
      "warnings": 0,
      "failures": 0,
      "exceptions": 0
    }
  },
  "policy_details": {
    "policy_file": "policy/deny.rego",
    "specific_rules": [
      " ECR repository `scrooge_ecr` does not have image tag mutability set"
    ]
  },
  "timing": {
    "remediation_start_time": "2025-11-09T01:57:19.353500Z",
    "remediation_end_time": "2025-11-09T01:57:33.694773Z",
    "total_duration_seconds": 14.34
  }
}
```